### PR TITLE
Add ability to report on rejection errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ usage[0-9][0-9].csv
 usage.err
 usage.log
 usage.rej
+usage[0-9][0-9].rej

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ appropriate:
 * `fa_user`: The username of a user that has rights to insert meter readings
   (and ideally no other permissions).
 * `fa_password`: That user's password.
+* `smtp_server`: The SMTP server to use for sending email notifications for
+  some rejection errors. If unset, no email will be sent.
+* `email_to`: The email address(es) to send notifications to, comma-separated.
+* `email_from`: The email address to use as the "from" address in the
+  notification emails.
 
 # Input file format
 
@@ -53,3 +58,4 @@ _major_ modifications to the screens and controls. It was generated using the
   this file because you could, in theory, manually edit the file and only
   re-process the rejections.
 * `usageNN.csv` a backup copy of the downloaded file from day NN of the month.
+* `usageNN.rej` a backup copy of the rejection file from day NN of the month.

--- a/config.example
+++ b/config.example
@@ -4,3 +4,7 @@ fa_address=192.0.2.1
 fa_port=1234
 fa_user=USERNAME
 fa_password=PASSWORD
+# Optional, if unspecified no email will be sent
+#smtp_server=smtp.example.com
+email_to=alice@example.com,bob@example.com
+email_from=noreply@example.com

--- a/import.ps1
+++ b/import.ps1
@@ -69,14 +69,14 @@ if (($rej_lines = Get-Content $rej).Length -gt 2) {
 
   # Send email if there are errors and there are email settings configured
   if ($errors.Count -gt 0 -and $config.smtp_server) {
-    $mail_body = "The following records were rejected by FA during import:`n`n"
+    $mail_body = "The following mileage records were rejected by FA during import:`n`n"
     foreach ($e in $errors) {
       $mail_body += "Rejected: $($e.Rejected)`nError: $($e.Error)`n`n"
     }
 
     Send-MailMessage -To ($config.email_to -split "\s*,\s*") `
                      -From $config.email_from `
-                     -Subject "FA Import Errors" `
+                     -Subject "FA Mileage Import Errors" `
                      -Body $mail_body `
                      -SmtpServer $config.smtp_server `
   }

--- a/import.ps1
+++ b/import.ps1
@@ -39,9 +39,51 @@ Add-Content $log "[$(Get-Date -Format s)] - Starting Import"
 & $config.fa_gui $fa_args | Wait-Process
 Add-Content $log "[$(Get-Date -Format s)] - Import Complete"
 
+# Analyze rejections
+$rej = "$pwd\usage.rej"
+$errors = @()
+
+# Reject file contains rejected lines with a 2-line header.
+if ((Test-Path $rej) -and (Get-Content $rej).Length -gt 2) {
+  $rej_lines = Get-Content $rej | Select-Object -Skip 2
+  $rej_count = $rej_lines.Count
+
+  $err_lines = Get-Content $err | Select-Object -Last $rej_count
+
+  # Match-up the rejected lines with the error lines from the log
+  for ($i = 0; $i -lt $rej_count; $i++) {
+    $r = $rej_lines[$i]
+    $e = $err_lines[$i]
+
+    # 49: "Meter 1 value is less than last reading"
+    # 437: "Meter 1 value is out of edit range from last reading"
+    if ($e -match "PR-ERR:\s+(\d+)" -and $Matches[1] -in @("49", "437")) {
+      $errors += @{
+        Rejected = $r
+        Error = $e
+      }
+    }
+  }
+
+  # Send email if there are errors and there are email settings configured
+  if ($errors.Count -gt 0 -and $config.smtp_server) {
+    $mail_body = "The following records were rejected by FA during import:`n`n"
+    foreach ($e in $errors) {
+      $mail_body += "Rejected: $($e.Rejected)`nError: $($e.Error)`n`n"
+    }
+
+    Send-MailMessage -To ($config.email_to -split "\s*,\s*") `
+                     -From $config.email_from `
+                     -Subject "FA Import Errors" `
+                     -Body $mail_body `
+                     -SmtpServer $config.smtp_server `
+  }
+}
+
 # Archive inputs/outputs
 $day = Get-Date -Format dd
 Copy-Item -Path $dest -Destination ($dest.BaseName + $day + $dest.Extension)
+Copy-Item -Path $rej -Destination ($rej.BaseName + $day + $rej.Extension)
 
 Get-Content $log | Select -Last 500 | Set-Content $log
 Get-Content $err | Select -Last 500 | Set-Content $err

--- a/import.ps1
+++ b/import.ps1
@@ -28,6 +28,9 @@ Else { $log = New-Item -ItemType File -Path "$pwd\usage.log" }
 If (Test-Path "$pwd\usage.err") { $err = Get-ChildItem "$pwd\usage.err" }
 Else { $err = New-Item -ItemType File -Path "$pwd\usage.err" }
 
+If (Test-Path "$pwd\usage.rej") { $rej = Get-ChildItem "$pwd\usage.rej" }
+Else { $rej = New-Item -ItemType File -Path "$pwd\usage.rej" }
+
 # Launch FA
 $fa_args = @(
   "$($config.fa_address):$($config.fa_port)",
@@ -40,12 +43,11 @@ Add-Content $log "[$(Get-Date -Format s)] - Starting Import"
 Add-Content $log "[$(Get-Date -Format s)] - Import Complete"
 
 # Analyze rejections
-$rej = "$pwd\usage.rej"
 $errors = @()
 
 # Reject file contains rejected lines with a 2-line header.
-if ((Test-Path $rej) -and (Get-Content $rej).Length -gt 2) {
-  $rej_lines = Get-Content $rej | Select-Object -Skip 2
+if (($rej_lines = Get-Content $rej).Length -gt 2) {
+  $rej_lines = $rej_lines | Select-Object -Skip 2
   $rej_count = $rej_lines.Count
 
   $err_lines = Get-Content $err | Select-Object -Last $rej_count


### PR DESCRIPTION
FA's file spec for error reporting is _terrible_, but I think I've got something that is somewhat useful here. Essentially, if there are N rejections then the last N lines of the error log are for those (probably). Pair them together, select the ones we care about, and email someone about it.